### PR TITLE
feat: Mock EDV APIs: Create Vault, Store/Retrieve Document - Simple in-memory DB

### DIFF
--- a/cmd/edge-auth-rest/startcmd/start.go
+++ b/cmd/edge-auth-rest/startcmd/start.go
@@ -8,7 +8,6 @@ package startcmd
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -94,9 +93,6 @@ func startEdgeAuth(parameters *edgeAuthParameters) error {
 	}
 
 	err = parameters.srv.ListenAndServe(parameters.hostURL, router)
-	if err != nil {
-		return fmt.Errorf("edge-auth server closed unexpectedly: %s", err)
-	}
 
-	return nil
+	return err
 }

--- a/cmd/edge-store-rest/go.sum
+++ b/cmd/edge-store-rest/go.sum
@@ -47,6 +47,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
@@ -86,6 +87,7 @@ golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f h1:25KHgbfyiSm6vwQLbM3zZIe1v9p/3ea4Rz+nnM5K/i4=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/pkg/restapi/edv/controller.go
+++ b/pkg/restapi/edv/controller.go
@@ -1,0 +1,32 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package edv
+
+import (
+	"github.com/trustbloc/edge-store/pkg/restapi/edv/operation"
+	"github.com/trustbloc/edge-store/pkg/storage"
+)
+
+// New returns new controller instance.
+func New(provider storage.Provider) (*Controller, error) {
+	var allHandlers []operation.Handler
+
+	edvService := operation.New(provider)
+	allHandlers = append(allHandlers, edvService.GetRESTHandlers()...)
+
+	return &Controller{handlers: allHandlers}, nil
+}
+
+// Controller contains handlers for controller
+type Controller struct {
+	handlers []operation.Handler
+}
+
+// GetOperations returns all controller endpoints
+func (c *Controller) GetOperations() []operation.Handler {
+	return c.handlers
+}

--- a/pkg/restapi/edv/controller_test.go
+++ b/pkg/restapi/edv/controller_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package edv
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestController_New(t *testing.T) {
+	controller, err := New(nil)
+	require.NoError(t, err)
+	require.NotNil(t, controller)
+}
+
+func TestController_GetOperations(t *testing.T) {
+	controller, err := New(nil)
+	require.NoError(t, err)
+	require.NotNil(t, controller)
+
+	ops := controller.GetOperations()
+
+	require.Equal(t, 3, len(ops))
+
+	require.Equal(t, "/data-vaults", ops[0].Path())
+	require.Equal(t, http.MethodPost, ops[0].Method())
+	require.NotNil(t, ops[0].Handle())
+
+	require.Equal(t, "/encrypted-data-vaults/{vaultID}/docs", ops[1].Path())
+	require.Equal(t, http.MethodPost, ops[1].Method())
+	require.NotNil(t, ops[1].Handle())
+
+	require.Equal(t, "/encrypted-data-vaults/{vaultID}/docs/{docID}", ops[2].Path())
+	require.Equal(t, http.MethodGet, ops[2].Method())
+	require.NotNil(t, ops[2].Handle())
+}

--- a/pkg/restapi/edv/operation/models.go
+++ b/pkg/restapi/edv/operation/models.go
@@ -1,0 +1,28 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package operation
+
+type dataVaultConfiguration struct {
+	Sequence    int        `json:"sequence"`
+	Controller  string     `json:"controller"`
+	Invoker     string     `json:"invoker"`
+	Delegator   string     `json:"delegator"`
+	ReferenceID string     `json:"referenceId"`
+	KEK         idTypePair `json:"kek"`
+	HMAC        idTypePair `json:"hmac"`
+}
+
+type idTypePair struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}
+
+type structuredDocument struct {
+	ID      string                 `json:"id"`
+	Meta    map[string]interface{} `json:"meta"`
+	Content map[string]interface{} `json:"content"`
+}

--- a/pkg/restapi/edv/operation/operations.go
+++ b/pkg/restapi/edv/operation/operations.go
@@ -1,0 +1,245 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package operation
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/trustbloc/edge-store/pkg/internal/common/support"
+	"github.com/trustbloc/edge-store/pkg/storage"
+)
+
+const (
+	vaultIDPathVariable = "vaultID"
+	docIDPathVariable   = "docID"
+
+	createVaultEndpoint      = "/data-vaults"
+	storeDocumentEndpoint    = "/encrypted-data-vaults/{" + vaultIDPathVariable + "}/docs"
+	retrieveDocumentEndpoint = "/encrypted-data-vaults/{" + vaultIDPathVariable + "}/docs/{" + docIDPathVariable + "}"
+)
+
+var errVaultNotFound = errors.New("specified vault does not exist")
+var errDocumentNotFound = errors.New("specified document does not exist")
+var errDuplicateVault = errors.New("vault already exists")
+var errDuplicateDocument = errors.New("a document with the given id already exists")
+
+// Handler http handler for each controller API endpoint
+type Handler interface {
+	Path() string
+	Method() string
+	Handle() http.HandlerFunc
+}
+
+// New returns EDV instance
+func New(provider storage.Provider) *Operation {
+	svc := &Operation{
+		vaultCollection: VaultCollection{
+			provider:   provider,
+			openStores: make(map[string]storage.Store),
+		}}
+	svc.registerHandler()
+
+	return svc
+}
+
+// Operation defines handlers for EDV service
+type Operation struct {
+	handlers        []Handler
+	vaultCollection VaultCollection
+}
+
+// VaultCollection represents EDV storage.
+type VaultCollection struct {
+	provider   storage.Provider
+	openStores map[string]storage.Store
+}
+
+func (c *Operation) createDataVaultHandler(rw http.ResponseWriter, req *http.Request) {
+	config := dataVaultConfiguration{}
+
+	err := json.NewDecoder(req.Body).Decode(&config)
+	if err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+
+		_, err = rw.Write([]byte(fmt.Sprintf("Data vault creation failed: %s", err)))
+		if err != nil {
+			log.Errorf("Failed to write response for data vault creation failure (unable to read request): %s", err.Error())
+		}
+
+		return
+	}
+
+	err = c.vaultCollection.createDataVault(config.ReferenceID)
+	if err != nil {
+		if err == errDuplicateVault {
+			rw.WriteHeader(http.StatusConflict)
+		} else {
+			rw.WriteHeader(http.StatusBadRequest)
+		}
+
+		_, err = rw.Write([]byte(fmt.Sprintf("Data vault creation failed: %s", err)))
+		if err != nil {
+			log.Errorf("Failed to write response for data vault creation failure: %s",
+				err.Error())
+		}
+
+		return
+	}
+
+	rw.WriteHeader(http.StatusCreated)
+
+	_, err = rw.Write([]byte("Location: " + req.Host + "/encrypted-data-vaults/" + config.ReferenceID))
+	if err != nil {
+		log.Errorf("Failed to write response for data vault creation success: %s", err.Error())
+	}
+}
+
+func (c *Operation) storeDocumentHandler(rw http.ResponseWriter, req *http.Request) {
+	incomingDocument := structuredDocument{}
+
+	err := json.NewDecoder(req.Body).Decode(&incomingDocument)
+	if err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+
+		_, err = rw.Write([]byte(fmt.Sprintf("Failed to store document: %s", err)))
+		if err != nil {
+			log.Errorf("Failed to write response for document storage failure: %s",
+				err.Error())
+		}
+
+		return
+	}
+
+	vars := mux.Vars(req)
+	vaultID := vars[vaultIDPathVariable]
+
+	err = c.vaultCollection.storeDocument(vaultID, incomingDocument)
+	if err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+
+		_, err = rw.Write([]byte(fmt.Sprintf("Failed to store document: %s", err)))
+		if err != nil {
+			log.Errorf(
+				"Failed to write response for document storage failure: %s", err.Error())
+		}
+
+		return
+	}
+
+	rw.WriteHeader(http.StatusCreated)
+
+	_, err = rw.Write([]byte("Location: " + req.Host + "/encrypted-data-vaults/" + vaultID +
+		"/docs/" + incomingDocument.ID))
+	if err != nil {
+		log.Errorf("Failed to write response for document storage success: %s", err.Error())
+	}
+}
+
+func (c *Operation) retrieveDocumentHandler(rw http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	vaultID := vars[vaultIDPathVariable]
+	docID := vars[docIDPathVariable]
+
+	documentJSON, err := c.vaultCollection.retrieveDocument(vaultID, docID)
+	if err != nil {
+		if err == errDocumentNotFound {
+			rw.WriteHeader(http.StatusNotFound)
+		} else {
+			rw.WriteHeader(http.StatusBadRequest)
+		}
+
+		_, err = rw.Write([]byte(fmt.Sprintf("Failed to retrieve document: %s", err.Error())))
+		if err != nil {
+			log.Errorf("Failed to write response for document retrieval failure: %s", err.Error())
+		}
+
+		return
+	}
+
+	_, err = rw.Write(documentJSON)
+	if err != nil {
+		log.Errorf("Failed to write response for document retrieval success: %s",
+			err.Error())
+	}
+}
+
+func (vc *VaultCollection) createDataVault(id string) error {
+	_, exists := vc.openStores[id]
+	if exists {
+		return errDuplicateVault
+	}
+
+	store, err := vc.provider.OpenStore(id)
+	if err != nil {
+		return err
+	}
+
+	vc.openStores[id] = store
+
+	return nil
+}
+
+func (vc *VaultCollection) storeDocument(vaultID string, document structuredDocument) error {
+	vault, exists := vc.openStores[vaultID]
+	if !exists {
+		return errVaultNotFound
+	}
+
+	// The Store Document API call should not overwrite an existing document.
+	// So we first check to make sure there is not already a document associated with the id.
+	// If there is, we send back an error.
+	_, err := vault.Get(document.ID)
+	if err == nil {
+		return errDuplicateDocument
+	} else if err != storage.ErrValueNotFound {
+		return err
+	}
+
+	documentJSON, err := json.Marshal(document)
+	if err != nil {
+		return err
+	}
+
+	return vault.Put(document.ID, documentJSON)
+}
+
+func (vc *VaultCollection) retrieveDocument(vaultID, docID string) ([]byte, error) {
+	vault, exists := vc.openStores[vaultID]
+	if !exists {
+		return nil, errVaultNotFound
+	}
+
+	documentJSON, err := vault.Get(docID)
+	if err == storage.ErrValueNotFound {
+		return nil, errDocumentNotFound // Returns a more specific error message
+	} else if err != nil {
+		return nil, err
+	}
+
+	return documentJSON, err
+}
+
+// registerHandler register handlers to be exposed from this service as REST API endpoints
+func (c *Operation) registerHandler() {
+	// Add more protocol endpoints here to expose them as controller API endpoints
+	c.handlers = []Handler{
+		support.NewHTTPHandler(createVaultEndpoint, http.MethodPost, c.createDataVaultHandler),
+		support.NewHTTPHandler(storeDocumentEndpoint, http.MethodPost, c.storeDocumentHandler),
+		support.NewHTTPHandler(retrieveDocumentEndpoint, http.MethodGet, c.retrieveDocumentHandler),
+	}
+}
+
+// GetRESTHandlers get all controller API handler available for this service
+func (c *Operation) GetRESTHandlers() []Handler {
+	return c.handlers
+}

--- a/pkg/restapi/edv/operation/operations_test.go
+++ b/pkg/restapi/edv/operation/operations_test.go
@@ -1,0 +1,319 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package operation
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+
+	"github.com/trustbloc/edge-store/pkg/storage/memstore"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testVaultID = "urn:uuid:abc5a436-21f9-4b4c-857d-1f5569b2600d"
+
+	testDataVaultConfiguration = `{
+  "sequence": 0,
+  "controller": "did:example:123456789",
+  "referenceId": "` + testVaultID + `",
+  "kek": {
+    "id": "https://example.com/kms/12345",
+    "type": "AesKeyWrappingKey2019"
+  },
+  "hmac": {
+    "id": "https://example.com/kms/67891",
+    "type": "Sha256HmacKey2019"
+  }
+}`
+
+	testDocID = "urn:uuid:94684128-c42c-4b28-adb0-aec77bf76045"
+
+	testStructuredDocument = `{
+  "id":"` + testDocID + `",
+  "meta": {
+    "created": "2019-06-18"
+  },
+  "content": {
+    "message": "Hello World!"
+  }
+}`
+)
+
+func TestCreateDataVaultHandler_InvalidDataVaultConfigurationJSON(t *testing.T) {
+	op := New(memstore.NewProvider())
+
+	createVaultHandler := getHandler(t, op, createVaultEndpoint)
+
+	req, err := http.NewRequest(http.MethodPost, "/data-vaults", bytes.NewBuffer([]byte("")))
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+
+	createVaultHandler.Handle().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "Data vault creation failed: EOF")
+}
+
+func TestCreateDataVaultHandler_ValidDataVaultConfigurationJSON(t *testing.T) {
+	op := New(memstore.NewProvider())
+
+	createDataVaultExpectSuccess(t, op)
+}
+
+func TestCreateDataVaultHandler_DuplicateDataVault(t *testing.T) {
+	op := New(memstore.NewProvider())
+
+	createDataVaultExpectSuccess(t, op)
+
+	req, err := http.NewRequest("POST", createVaultEndpoint, bytes.NewBuffer([]byte(testDataVaultConfiguration)))
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+
+	createVaultEndpointHandler := getHandler(t, op, createVaultEndpoint)
+	createVaultEndpointHandler.Handle().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusConflict, rr.Code)
+	require.Equal(t, "Data vault creation failed: vault already exists", rr.Body.String())
+}
+
+func TestStoreDocumentHandler_InvalidStructuredDocumentJSON(t *testing.T) {
+	op := New(memstore.NewProvider())
+
+	storeDocumentEndpointHandler := getHandler(t, op, storeDocumentEndpoint)
+
+	req, err := http.NewRequest("POST", storeDocumentEndpoint, bytes.NewBuffer([]byte("")))
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+
+	storeDocumentEndpointHandler.Handle().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "Failed to store document: EOF")
+}
+
+func TestStoreDocumentHandler_ValidStructuredDocumentJSON(t *testing.T) {
+	op := New(memstore.NewProvider())
+
+	createDataVaultExpectSuccess(t, op)
+
+	storeStructuredDocumentExpectSuccess(t, op)
+}
+
+func TestStoreDocumentHandler_DuplicateDocuments(t *testing.T) {
+	op := New(memstore.NewProvider())
+
+	createDataVaultExpectSuccess(t, op)
+
+	storeStructuredDocumentExpectSuccess(t, op)
+
+	req, err := http.NewRequest("POST", "/encrypted-data-vaults/"+testVaultID+"/docs",
+		bytes.NewBuffer([]byte(testStructuredDocument)))
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+
+	urlVars := make(map[string]string)
+	urlVars[vaultIDPathVariable] = testVaultID
+
+	req = mux.SetURLVars(req, urlVars)
+
+	storeDocumentEndpointHandler := getHandler(t, op, storeDocumentEndpoint)
+	storeDocumentEndpointHandler.Handle().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "a document with the given id already exists")
+}
+
+func TestStoreDocumentHandler_VaultDoesNotExist(t *testing.T) {
+	op := New(memstore.NewProvider())
+	storeDocumentEndpointHandler := getHandler(t, op, storeDocumentEndpoint)
+
+	req, err := http.NewRequest("POST", "/encrypted-data-vaults/"+testVaultID+"/docs",
+		bytes.NewBuffer([]byte(testStructuredDocument)))
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+
+	urlVars := make(map[string]string)
+	urlVars[vaultIDPathVariable] = testVaultID
+
+	req = mux.SetURLVars(req, urlVars)
+
+	storeDocumentEndpointHandler.Handle().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "specified vault does not exist")
+}
+
+func TestRetrieveDocumentHandler_VaultDoesNotExist(t *testing.T) {
+	op := New(memstore.NewProvider())
+	retrieveDocumentEndpointHandler := getHandler(t, op, retrieveDocumentEndpoint)
+
+	req, err := http.NewRequest(http.MethodPost,
+		"/encrypted-data-vaults/"+testVaultID+"/"+
+			"docs/"+testDocID,
+		bytes.NewBuffer([]byte("")))
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+
+	urlVars := make(map[string]string)
+	urlVars[vaultIDPathVariable] = testVaultID
+	urlVars[docIDPathVariable] = testDocID
+
+	req = mux.SetURLVars(req, urlVars)
+
+	retrieveDocumentEndpointHandler.Handle().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "specified vault does not exist")
+}
+
+func TestRetrieveDocumentHandler_DocumentDoesNotExist(t *testing.T) {
+	op := New(memstore.NewProvider())
+
+	createDataVaultExpectSuccess(t, op)
+
+	retrieveDocumentEndpointHandler := getHandler(t, op, retrieveDocumentEndpoint)
+
+	req, err := http.NewRequest(http.MethodPost,
+		"/encrypted-data-vaults/"+testVaultID+"/"+
+			"docs/"+testDocID,
+		bytes.NewBuffer([]byte("")))
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+
+	urlVars := make(map[string]string)
+	urlVars[vaultIDPathVariable] = testVaultID
+	urlVars[docIDPathVariable] = testDocID
+
+	req = mux.SetURLVars(req, urlVars)
+
+	retrieveDocumentEndpointHandler.Handle().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	require.Contains(t, rr.Body.String(), "specified document does not exist")
+}
+
+func TestRetrieveDocumentHandler_DocumentExists(t *testing.T) {
+	op := New(memstore.NewProvider())
+
+	createDataVaultExpectSuccess(t, op)
+
+	storeStructuredDocumentExpectSuccess(t, op)
+
+	retrieveDocumentEndpointHandler := getHandler(t, op, retrieveDocumentEndpoint)
+
+	req, err := http.NewRequest(http.MethodPost,
+		"/encrypted-data-vaults/"+testVaultID+"/docs/"+testDocID,
+		bytes.NewBuffer([]byte("")))
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+
+	urlVars := make(map[string]string)
+	urlVars[vaultIDPathVariable] = testVaultID
+	urlVars[docIDPathVariable] = testDocID
+
+	req = mux.SetURLVars(req, urlVars)
+
+	retrieveDocumentEndpointHandler.Handle().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	const expectedData = `{"id":"` + testDocID + `","meta":{"created":"2019-06-18"},"content":{"message":"Hello World!"}}`
+
+	require.Equal(t, expectedData, rr.Body.String())
+}
+
+func TestStoreDocument_FailToMarshal(t *testing.T) {
+	op := New(memstore.NewProvider())
+
+	newStore, err := op.vaultCollection.provider.OpenStore("store1")
+	require.NoError(t, err)
+
+	op.vaultCollection.openStores["store1"] = newStore
+
+	unmarshallableMap := make(map[string]interface{})
+	unmarshallableMap["somewhere"] = make(chan int)
+
+	err = op.vaultCollection.storeDocument("store1", structuredDocument{
+		ID:      "",
+		Meta:    unmarshallableMap,
+		Content: nil,
+	})
+
+	require.Equal(t, "json: unsupported type: chan int", err.Error())
+}
+
+func createDataVaultExpectSuccess(t *testing.T, op *Operation) {
+	req, err := http.NewRequest(http.MethodPost, createVaultEndpoint, bytes.NewBuffer([]byte(testDataVaultConfiguration)))
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+
+	createVaultEndpointHandler := getHandler(t, op, createVaultEndpoint)
+	createVaultEndpointHandler.Handle().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusCreated, rr.Code)
+	require.Equal(t, "Location: /encrypted-data-vaults/"+testVaultID, rr.Body.String())
+}
+
+func storeStructuredDocumentExpectSuccess(t *testing.T, op *Operation) {
+	req, err := http.NewRequest("POST", "/encrypted-data-vaults/"+testVaultID+"/docs",
+		bytes.NewBuffer([]byte(testStructuredDocument)))
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+
+	urlVars := make(map[string]string)
+	urlVars[vaultIDPathVariable] = testVaultID
+
+	req = mux.SetURLVars(req, urlVars)
+
+	storeDocumentEndpointHandler := getHandler(t, op, storeDocumentEndpoint)
+
+	storeDocumentEndpointHandler.Handle().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusCreated, rr.Code)
+	require.Equal(t,
+		"Location: /encrypted-data-vaults/"+testVaultID+"/"+"docs/"+testDocID,
+		rr.Body.String())
+}
+
+func getHandler(t *testing.T, op *Operation, lookup string) Handler {
+	return getHandlerWithError(t, op, lookup)
+}
+
+func getHandlerWithError(t *testing.T, op *Operation, lookup string) Handler {
+	return handlerLookup(t, op, lookup)
+}
+
+func handlerLookup(t *testing.T, op *Operation, lookup string) Handler {
+	handlers := op.GetRESTHandlers()
+	require.NotEmpty(t, handlers)
+
+	for _, h := range handlers {
+		if h.Path() == lookup {
+			return h
+		}
+	}
+
+	require.Fail(t, "unable to find handler")
+
+	return nil
+}

--- a/pkg/storage/memstore/memstore.go
+++ b/pkg/storage/memstore/memstore.go
@@ -1,0 +1,90 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package memstore
+
+import (
+	"github.com/trustbloc/edge-store/pkg/storage"
+)
+
+// Provider represents an MemStore implementation of the storage.Provider interface
+type Provider struct {
+	dbs map[string]*MemStore
+}
+
+// NewProvider instantiates Provider
+func NewProvider() *Provider {
+	return &Provider{dbs: make(map[string]*MemStore)}
+}
+
+// OpenStore opens and returns a store for the given name.
+func (p *Provider) OpenStore(name string) (storage.Store, error) {
+	store, exists := p.dbs[name]
+	if !exists {
+		return p.newMemStore(name), nil
+	}
+
+	return store, nil
+}
+
+func (p *Provider) newMemStore(name string) *MemStore {
+	store := MemStore{db: make(map[string][]byte)}
+
+	p.dbs[name] = &store
+
+	return &store
+}
+
+// CloseStore closes a previously opened store.
+func (p *Provider) CloseStore(name string) error {
+	store, exists := p.dbs[name]
+	if !exists {
+		return storage.ErrStoreNotFound
+	}
+
+	delete(p.dbs, name)
+
+	store.close()
+
+	return nil
+}
+
+// Close closes the provider.
+func (p *Provider) Close() error {
+	for _, memStore := range p.dbs {
+		memStore.db = make(map[string][]byte)
+	}
+
+	p.dbs = make(map[string]*MemStore)
+
+	return nil
+}
+
+// MemStore is a simple DB that's stored in memory. Useful for demos or testing. Not designed to be performant.
+type MemStore struct {
+	db map[string][]byte
+}
+
+// Put stores the given key-value pair in the store.
+func (store *MemStore) Put(k string, v []byte) error {
+	store.db[k] = v
+
+	return nil
+}
+
+// Get retrieves the value in the store associated with the given key.
+func (store *MemStore) Get(k string) ([]byte, error) {
+	v, exists := store.db[k]
+	if !exists {
+		return nil, storage.ErrValueNotFound
+	}
+
+	return v, nil
+}
+
+func (store *MemStore) close() {
+	store.db = make(map[string][]byte)
+}

--- a/pkg/storage/memstore/memstore_test.go
+++ b/pkg/storage/memstore/memstore_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package memstore
+
+import (
+	"testing"
+
+	"github.com/trustbloc/edge-store/pkg/storage"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemStore_OpenStore(t *testing.T) {
+	provider := NewProvider()
+
+	newStore, err := provider.OpenStore("store1")
+	require.NoError(t, err)
+	require.IsType(t, &MemStore{}, newStore)
+}
+
+func TestMemStore_OpenExistingStore(t *testing.T) {
+	provider := NewProvider()
+
+	newStore, err := provider.OpenStore("store1")
+	require.NoError(t, err)
+	require.IsType(t, &MemStore{}, newStore)
+
+	existingStore, err := provider.OpenStore("store1")
+	require.NoError(t, err)
+	require.Equal(t, newStore, existingStore)
+}
+
+func TestProvider_Close(t *testing.T) {
+	provider := NewProvider()
+
+	_, err := provider.OpenStore("store1")
+	require.NoError(t, err)
+
+	_, err = provider.OpenStore("store2")
+	require.NoError(t, err)
+
+	err = provider.Close()
+	require.NoError(t, err)
+
+	require.Equal(t, 0, len(provider.dbs))
+}
+
+func TestProvider_CloseStore(t *testing.T) {
+	provider := NewProvider()
+
+	newStore, err := provider.OpenStore("store1")
+	require.NoError(t, err)
+
+	err = newStore.Put("something", []byte("value"))
+	require.NoError(t, err)
+
+	_, err = provider.OpenStore("store2")
+	require.NoError(t, err)
+
+	err = provider.CloseStore("store1")
+	require.NoError(t, err)
+
+	_, err = newStore.Get("something")
+	require.Equal(t, storage.ErrValueNotFound, err)
+
+	require.Equal(t, 1, len(provider.dbs))
+}
+
+func TestProvider_CloseStoreDoesNotExist(t *testing.T) {
+	provider := NewProvider()
+
+	err := provider.CloseStore("store1")
+	require.Equal(t, storage.ErrStoreNotFound, err)
+}
+
+func TestMemStore_Get(t *testing.T) {
+	memStore := MemStore{db: make(map[string][]byte)}
+
+	memStore.db["testKey"] = []byte("testValue")
+
+	value, err := memStore.Get("testKey")
+	require.NoError(t, err)
+
+	require.Equal(t, []byte("testValue"), value)
+}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1,0 +1,36 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package storage
+
+import "errors"
+
+// ErrStoreNotFound is used when a given store was not found in a provider.
+var ErrStoreNotFound = errors.New("store not found")
+
+// ErrValueNotFound is used when an attempt is made to retrieve a value from key
+var ErrValueNotFound = errors.New("store does not have a value associated with this key")
+
+// Provider represents a storage provider.
+type Provider interface {
+	// OpenStore opens a store with the given name and returns it.
+	OpenStore(name string) (Store, error)
+
+	// CloseStore closes the store with the given name.
+	CloseStore(name string) error
+
+	// Close closes all stores created under this store provider.
+	Close() error
+}
+
+// Store represents a storage database.
+type Store interface {
+	// Put stores the key-record pair.
+	Put(k string, v []byte) error
+
+	// Get fetches the record associated with the given key.
+	Get(k string) ([]byte, error)
+}


### PR DESCRIPTION
Closes #27

Implementation of Create Vault and Store/Retrieve document API calls. Everything is unencrypted and stored in an in-memory database for now.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>